### PR TITLE
Geen kilometerheffing, voor gehandicapten geen MRB of BPM meer, auto's om laten rijden.

### DIFF
--- a/programma.md
+++ b/programma.md
@@ -533,6 +533,20 @@ BIJ1 heeft hiervoor de volgende plannen:
     moeten rechten krijgen om bescherming, behoud (en eventueel herstel) te waarborgen.
     De Waddenzee moet als eerste als zelfstandige rechtspersoonlijkheid aangemerkt worden.
 
+1.  Autorijden is voor mensen met een handicap, vele gezinnen en mensen buiten de randstad essentieel.
+    We pleiten niet voor een kilometerheffing of een verdere accijnsverhogingen op brandstoffen.
+    Met onze MIRT gaan we de concurrentie aan met auto's,
+    waardoor mensen eerder hun auto laten staan of er geen aanschaffen.
+    Zo zorgen we ervoor dat de kosten van klimaatverandering niet bij de gewone burger komt te liggen.
+
+1.  Voor mensen met een gehandicaptenpas komt er vrijstelling komen
+    op de motorrijtuigenbelasting (MRB) en aanschafbelasting (BPM).
+    Ook als dit geen aangepaste rolstoelbus betreft. Mobiliteit is een recht.
+
+1.  Wij schromen niet om auto's om te laten rijden ten opzichte van het openbaar vervoer of de fiets.
+    Zo worden fietsroute's en OV-routes automatisch efficiënter.
+    Het gebruik van 30km wegen moedigen wij aan.
+
 ## Internationale Klimaatrechtvaardigheid
 
 1.  Bedrijven die verantwoordelijk zijn


### PR DESCRIPTION
ingediend door: Jorn van 't Hof

Liberaal linkse partijen in Nederland willen mensen een auto uitprijzen in de hoop dat burgers een ander vervoersmiddel pakken. Dit is echter een verkeerd, neoliberaal denkbeeld. Veel mensen die een auto hebben, kunnen namelijk écht niet anders. Als je de concurrentie aan gaat met betere alternatieven krijg je mensen er echt wel uit.

Dit neemt niet weg dat je bijvoorbeeld kan nadenken over ongunstigere autoroute's, minder parkeerplaatsen of meer 30km/u zones, zodat OV en fietsen qua tijdswinst relatief efficiënter wordt.