### PR TITLE
Gratis kernenergie voor Nederlandse burgers.

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,8 +1,3 @@
-# MD002/first-heading-h1/first-header-h1 - First heading should be a top-level heading
-MD002:
-  # Heading level
-  level: 2
-
 # MD013/line-length - Line length
 MD013:
   # Number of characters
@@ -30,3 +25,8 @@ MD033:
 
 # MD034/no-bare-urls - Bare URL used
 MD034: false
+
+# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+MD041:
+  # Heading level
+  level: 2

--- a/README.md
+++ b/README.md
@@ -494,6 +494,13 @@ BIJ1 heeft hiervoor de volgende plannen:
     zodat mensen met lagere inkomens
     niet de rekening gepresenteerd krijgen voor de energietransitie.
 
+1.  We investeren in betrouwbare, uitstootvrije en genationaliseerde kernenergie.
+    Kerncentrales hebben een grote eenmalige investering nodig,
+    maar de operationele kosten zijn verwaarloosbaar.
+    Na de opening van de centrale kan je Nederlandse burgers voorzien van gratis stroom
+    en verdien je de centrale terug door bedrijven te laten voor elektriciteitsgebruik.
+    Kerncentrale's zorgen tevens voor veel hoogwaardige, langdurige banen in regio's met minder werkgelegenheid.
+
 ### Natuur en Vervoer
 
 1.  OV-bedrijven worden genationaliseerd.


### PR DESCRIPTION
ingediend door: Jorn van 't Hof

We moeten geen enkele technologie voor de energietransitie schuwen. Kernenergie is bewezen schoon, veilig en gruwelijk goedkoop. Ook zorgen kerncentrales voor hoogwaardige, veilige en langdurige banen met een grote bestaanszekerheid.

Het is absurd dat we rechtse partijen laten weglopen met deze technologie, die uitermate geschikt zijn voor klimaatrechtvaardigheid en een toekomst met 0% uitstoot.

Sidenote: Er zijn angsten dat uranium elders in de wereld gewonnen zal worden, maar dit is niet perse nodig. Ook in Zweden gaan ze beginnen met het winnen van uranium, terwijl zonnepanelen en windmolens ook worden opgebouwd met materialen uit achtergestelde landen.