### PR TITLE
Geen inkomensgrens op sociale huur.

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,13 @@ heeft BIJ1 de volgende plannen:
     We zetten extra in op het bouwen van
     passende, betaalbare en goede woningen voor jongeren en ouderen.
 
+1.  De inkomensgrens voor sociale huur verdwijnt.
+    In 2016 is er via de Wet Passend Toewijzen een maximale inkomensgrens ingesteld
+    om een sociale huurwoning te kunnen bemachtigen.
+    Uiteindelijk gaat Nederland naar een systeem toe
+    met alleen maar voldoende sociale huurwoningen voor iedere Nederlander
+    en stoppen we met vrije-sectorhuur en middenhuur.
+
 1.  We zorgen voor voldoende betaalbare woningen voor jongeren, studenten en starters.
     Daarnaast komt er een nationale jeugdstrategie
     waar jongeren betrokken worden in de ontwikkeling van nieuwe jongerenwoningen.


### PR DESCRIPTION
ingediend door: Jorn van 't Hof

De vrije sector en middenhuur zijn verschrikkelijk kapitalistisch en neoliberaal. Geef iedereen het échte recht op een woning en zorg dat iedereen weer toegang heeft tot een sociale huurwoning. Dit zorgt tevens voor meer gemengde wijken en voor een volgende stap naar onze socialistische droom.