### PR TITLE
Vliegvelden moeten flink krimpen om klimaatdoelen te halen

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,8 @@ BIJ1 heeft hiervoor de volgende plannen:
     Het openbaar vervoer wordt gratis en toegankelijk,
     en is uiterlijk in 2030 volledig elektrisch.
 
-1.  Nederlandse vliegvelden, waaronder Schiphol, mogen niet verder uitbreiden.
+1.  Nederlandse vliegvelden, waaronder Schiphol, worden verplicht hun vluchtaanbod zo aan te passen
+    dat uitstoot van broeikasgassen jaarlijks vermindert en in 2030 verwaarloosbaar is.
     Er komt BTW en accijns op kerosine,
     en we zetten ons op Europees niveau in om zo snel mogelijk
     op duurzame wijze een Europees spoornetwerk te realiseren.


### PR DESCRIPTION
ingediend door: Daniel van der Lek

Deze zin is in praktijk in tegenspraak met de eis een bladzijde eerder regels 320-322: "De Nederlandse uitstoot van broeikasgassen is in 2025 minstens 75% lager (in scope 1, 2 én 3 emissies) dan in 1990 en staat in 2030 op 0. Deze doelen worden wettelijk vastgelegd en zijn bindend. "