### PR TITLE
Pak de desinformatiecrisis aan!

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,11 @@ BIJ1 heeft hiervoor de volgende plannen:
     zodat mensen met lagere inkomens
     niet de rekening gepresenteerd krijgen voor de energietransitie.
 
+1.  Om de klimaatcrisis aan te pakken, moet eerst de desinformatiecrisis aangepakt worden.
+    Bij1 stelt een parlementaire commissie in die onderzoek doet naar de geschiedenis van desinformatie
+    ten aanzien van de menselijke invloed op klimaatverandering
+    en de mogelijkheid tot een verbod op desinformatie.
+
 ### Natuur en Vervoer
 
 1.  OV-bedrijven worden genationaliseerd.


### PR DESCRIPTION
ingediend door: Michael Hajkowski

In de jaren '90 was er de politieke wil om klimaatverandering tegen te gaan. Zelfs Thatcher had het er over. Tegelijk kwamen de grote fossiele bedrijven met een succesvolle propagandacampagne tegen klimaatwetenschap, zie de Global Climate Coalition. Verder zijn er bladen als De Telegraaf en Elsevier die de klimaatcrisis nog altijd bagatelliseren en ontkennen.