### PR TITLE
Weg met de opportunistische baantjesjagers!

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,8 +1,3 @@
-# MD002/first-heading-h1/first-header-h1 - First heading should be a top-level heading
-MD002:
-  # Heading level
-  level: 2
-
 # MD013/line-length - Line length
 MD013:
   # Number of characters
@@ -30,3 +25,8 @@ MD033:
 
 # MD034/no-bare-urls - Bare URL used
 MD034: false
+
+# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+MD041:
+  # Heading level
+  level: 2

--- a/README.md
+++ b/README.md
@@ -1905,6 +1905,13 @@ Daarvoor heeft BIJ1 de volgende kernpunten voor ogen:
     Gemeenten staan namelijk veel dichter bij de burgers voor wie ze het beleid maken en uitvoeren.
     Zij weten daarom beter dan de landelijke overheid wat er lokaal het hardst nodig is.
 
+1.  In overheids- en semioverheidsorganisaties dringen doorgaans opportunistische baantjesjagers
+    door tot bestuurlijke en managementposities.
+    Hierom is een onafhankelijke organisatie nodig die mensen selecteert op hun werkelijke kwaliteiten,
+    zoals inzicht en een karakter die het algemeen belang dient in plaats van het eigen belang.
+    Dit moet zo gebeuren dat ook de kwaliteiten
+    van mensen uit gemarginaliseerde groepen eindelijk eens erkend worden.
+
 ### Democratie voor Iedereen
 
 1.  Alle mensenrechtenverdragen, zoals het Kinderrechtenverdrag, het Vrouwenrechtenverdrag


### PR DESCRIPTION
ingediend door: Michael Hajkowski

In een aflevering van Zembla had Ben Tiggelaar het er over dat de carrièregerichte managers doorgaans promotie maken in plaats van de werkgerichte managers. De eerste richt zich op profileren en netwerken, de tweede richt zich op de werknemers en organisatie. Ik denk dat dit de reden is dat bijvoorbeeld kinderen in de jeugdzorg nog altijd niet adequaat bijgestaan worden. Dit is immers iets waarvan de overgrote meerderheid wilt dat dit goed geregeld is.