### PR TITLE
Nationaliseren van de energiesector in de strijd tegen de klimaatcrisis

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,8 +1,3 @@
-# MD002/first-heading-h1/first-header-h1 - First heading should be a top-level heading
-MD002:
-  # Heading level
-  level: 2
-
 # MD013/line-length - Line length
 MD013:
   # Number of characters
@@ -30,3 +25,8 @@ MD033:
 
 # MD034/no-bare-urls - Bare URL used
 MD034: false
+
+# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+MD041:
+  # Heading level
+  level: 2

--- a/README.md
+++ b/README.md
@@ -333,8 +333,9 @@ Om tot deze economie te komen, heeft BIJ1 de volgende kernpunten voor ogen:
 ### Van Privatisering naar Nationalisering
 
 1.  We brengen belangrijke sectoren van de economie,
-    zoals banken, pensioenfondsen, het openbaar vervoer en de zorg,
+    zoals banken, pensioenfondsen, energie, het openbaar vervoer en de zorg,
     in publieke handen.
+    De financiële en energiesector hebben hierbij de hoogste urgentie.
 
 1.  Nederland is niet langer een belastingparadijs.
     Het oprichten van een brievenbus-BV wordt onmogelijk gemaakt.


### PR DESCRIPTION
ingediend door: Bas Holtzer

De energiesector is op dit moment dé strategische sector om de klimaatcrisis aan te pakken. Dit is het grootste probleem waartegen we nu aanlopen en heeft dus een hoge urgentie. Fossiele energie moet zo snel mogelijk worden vervangen door electrificatie op basis van schone energiebronnen. Vanwege de enorme economische en financiële belangen kan niet worden verwacht dat de sector deze transitie vrijwillig gaat maken.

Door energie weer in publieke handen en onder democratische controle te brengen, kunnen we de winst-prikkel eruit halen en keuzes maken op basis van duurzame lange termijn-doelen. Energie en financiële wereld zijn nauw met elkaar verstrengeld, dus zullen beiden moeten worden aangepakt. Het nationaliseren van de financiële en energiesector is de enige manier om de nodige klimaatambities te realiseren.