### PR TITLE
Textuele verbetering punt over werknemersfonds

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,8 +1,3 @@
-# MD002/first-heading-h1/first-header-h1 - First heading should be a top-level heading
-MD002:
-  # Heading level
-  level: 2
-
 # MD013/line-length - Line length
 MD013:
   # Number of characters
@@ -30,3 +25,8 @@ MD033:
 
 # MD034/no-bare-urls - Bare URL used
 MD034: false
+
+# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+MD041:
+  # Heading level
+  level: 2

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Om tot deze economie te komen, heeft BIJ1 de volgende kernpunten voor ogen:
     waaraan zij jaarlijks een aantal nieuwe aandelen,
     proportioneel aan de jaarwinst, uitschrijven.
     Het werknemersfonds wordt uitsluitend beheerd
-    door de werknemers van de firma die haar heeft opgericht.
+    door de werknemers van dit bedrijf.
 
 1.  Er wordt grootschalig onderzoek gedaan naar het duurzaam oprichten
     van publieke banken en investeringsfondsen


### PR DESCRIPTION
ingediend door: Andrew Ammerlaan

Deze zin is te lezen alsof enkel de werknemers die het bedrijf hebben opgericht het fonds mogen beheren, in plaats van dat enkel werknemers werkzaam bij het bedrijf waarbij het fonds hoort dit fonds mogen beheren.

De nieuwe tekst is duidelijker en minder complex.