### PR TITLE
Breid reclame verbod uit

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,8 +539,13 @@ BIJ1 heeft hiervoor de volgende plannen:
 1.  Bedrijven die verantwoordelijk zijn
     voor het aanrichten van klimaatschade en humanitaire rampen,
     worden verantwoordelijk gehouden voor misdaden tegen mens en natuur.
-    Ecocide wordt strafbaar
-    en er komt een reclameverbod voor de fossiele industrie en vliegmaatschappijen.
+    Ecocide wordt strafbaar.
+
+1.  Het doel van reclame is om ervoor te zorgen dat mensen (meer) dingen kopen
+    die ze eigenlijk niet nodig hebben.
+    Dit is een onnodige belasting op het klimaat,
+    en daarom wordt deze consumptie-inducerende reclame verboden.
+    Enkel puur informerende advertenties blijven toegestaan.
 
 1.  Nederland zet zich in voor een forse herziening van het Europees landbouwbeleid,
     waarbij alleen nog subsidies worden verstrekt aan circulaire landbouw.


### PR DESCRIPTION
ingediend door: Andrew Ammerlaan

Reclame is uitgevonden om meer te verkopen door het induceren van een kunstmatige vraag. Wat door deze reclame (extra) wordt geconsumeerd is een onnodige belasting op het klimaat. Daarnaast is reclame enorm irritant. Alle reclame dient dus verboden te worden. (online) advertenties met een informerend (ipv financieel) doel moeten natuurlijk wel kunnen. Dus wel “het is weer asperge seizoen” maar niet “nu 1+1 gratis” (insert kruidvat-deuntje), “spaar actiezegels en ontvang …”, of “koop nu deze super coole BMW, zo veel beter dan de auto die je al hebt” (insert beelden van auto die door scandinavisch landschap rijdt).