### PR TITLE
Textuele verbetering punt over racisme op de woningmarkt

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,8 +1,3 @@
-# MD002/first-heading-h1/first-header-h1 - First heading should be a top-level heading
-MD002:
-  # Heading level
-  level: 2
-
 # MD013/line-length - Line length
 MD013:
   # Number of characters
@@ -30,3 +25,8 @@ MD033:
 
 # MD034/no-bare-urls - Bare URL used
 MD034: false
+
+# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+MD041:
+  # Heading level
+  level: 2

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Hiervoor heeft BIJ1 de volgende kernpunten voor ogen:
     Het is tijd om op basis daarvan antiracistisch beleid vorm te geven,
     onder andere door gentrificatie tegen te gaan.
     Woningcorporaties moeten actief aantonen dat zij niet discrimineren.
-    Leegstaande panden worden daarnaast ook gebruikt voor de ontwikkeling en emancipatie
+    Leegstaande panden zullen onder andere worden gebruikt voor de ontwikkeling en emancipatie
     van jongeren van kleur en voor de opvang van ongedocumenteerde mensen.
 
 1.  We pakken racisme in het onderwijs aan.


### PR DESCRIPTION
ingediend door: Andrew Ammerlaan

"daarnaast ook" leest alsof het onderwerp van de voorgaande zinnen "leegstaande panden" is, dit is niet het geval want we hebben het hier over racisme op de woningmarkt. Na deze wijziging leest dit punt makkelijker en komt het onderwerp van dit punt beter naar voren.