### PR TITLE
Betere verwoording van het punt over facisten en nazi-attributen

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,8 +1,3 @@
-# MD002/first-heading-h1/first-header-h1 - First heading should be a top-level heading
-MD002:
-  # Heading level
-  level: 2
-
 # MD013/line-length - Line length
 MD013:
   # Number of characters
@@ -30,3 +25,8 @@ MD033:
 
 # MD034/no-bare-urls - Bare URL used
 MD034: false
+
+# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+MD041:
+  # Heading level
+  level: 2

--- a/README.md
+++ b/README.md
@@ -115,9 +115,8 @@ Hiervoor heeft BIJ1 de volgende kernpunten voor ogen:
     als antisemitisch beoordeelt, wordt verworpen.
     Er komt ook erkenning voor het antisemitisme binnen de Zionistische beweging,
     zoals dat van Viktor Orbán en extremistische christenen.
-    Het bezit van nazi-attributen mag voortaan alleen met een vergunning,
-    behalve in musea.
-    Hitleraanbidding wordt bij wet verboden.
+    Het bezit van nazi-attributen mag voortaan alleen met een vergunning.
+    Aanbidding of verheerlijking van prominente fascisten, zoals Hitler, wordt bij wet verboden.
 
 ### Koloniale Schade Herstellen en Hedendaags Kolonialisme Afbreken
 


### PR DESCRIPTION
ingediend door: Andrew Ammerlaan

Het aanbidden van andere fascisten zoals Mussolini of Franco is ook verwerpelijk en dient dus ook verboden te worden. Hitler blijft erin staan als voorbeeld zodat het duidelijk is wat er met dit punt bedoeld wordt.

De uitzondering "behalve voor musea" wordt er hier uitgehaald. Aan deze musea kan simpelweg een vergunning worden verleend. Door zonder condities musea een uitzonderingspositie te bieden is er geen controle over dat de nazi-attributen in een museum wel verantwoord worden gebruikt. In andere woorden, in de oorspronkelijke tekst is er geen reden waarom fascisten niet een nazi-attributen museum kunnen openen waar deze voorwerpen tentoon gesteld worden zonder context of met verkeerde context.