### PR TITLE
Verduidelijk punt over inclusief medisch onderzoek

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ Daarvoor heeft BIJ1 de volgende kernpunten voor ogen:
 1.  Niet alleen de witte cis man moet centraal staan bij medisch onderzoek.
     Er wordt meer geïnvesteerd in onderzoek
     naar ziektebeelden, geneesmiddelen en behandelmethoden
-    bij niet-witte mensen, vrouwen en niet-witte vrouwen.
+    bij mensen die niet wit, cis, en/of man zijn.
 
 1.  In de opleiding van artsen, hulpverleners, thuis- en ouderenzorg en medisch personeel
     komt meer aandacht voor de bestrijding van racistische stereotypen.


### PR DESCRIPTION
ingediend door: Andrew Ammerlaan

Het benoemen van “vrouwen” en “niet-witte vrouwen” als aparte groep leest raar. Daarnaast dienen non-binaire mensen ook meegenomen te worden in deze zin. De nieuwe verwoording is meer inclusief en tevens duidelijker.