### PR TITLE
Excuses vallen niet jurdisch of wetterlijk vast te leggen

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,8 +916,7 @@ Daarvoor heeft BIJ1 de volgende kernpunten voor ogen:
 
 1.  Nederland herstelt de schade van het slavernijverleden
     en de doorwerking daarvan in het heden.
-    De excuses voor de slavernij en het kolonialisme,
-    de invulling van het herstelproces en de uitkomsten
+    De invulling van het herstelproces en de uitkomsten
     worden juridisch bindend en vastgelegd in een
     consensusrijkswet Herstelmaatregelen.
     Deze reparaties zullen zowel materieel als immaterieel zijn,


### PR DESCRIPTION
ingediend door: Andrew Ammerlaan

Excuses (hoewel uiterst belangrijk) kunnen niet juridisch of wettelijk vastgelegd worden. Excuses zijn enkel waardevol als deze vrijwillig en gemeend gegeven worden, het juridisch en/of wettelijk vastleggen van excuses ontneemt deze oprechtheid doordat deze dan geforceerd is. De oprechtheid en gemeendheid van excuses moeten blijken uit handelingen. Handelingen en doelstellingen kunnen wel juridisch en wettelijk worden vastgelegd, dat gedeelte van de zin blijft dus staan.