### PR TITLE
Geen verplichte aparte vakbond voor arbeidsmigranten

### DIFF
--- a/README.md
+++ b/README.md
@@ -1132,8 +1132,8 @@ Dit doen we op de volgende manieren:
 1.  Het mandaat van de IND wordt omgezet in een loketfunctie
     om mensen op weg te helpen in Nederland.
 
-1.  Arbeidsmigranten krijgen een eigen vakbond
-    die kan opkomen voor het waarborgen van hun rechten,
+1.  Arbeidsmigranten mogen volwaardig lid worden van een bestaande vakbond,
+    of mogen een eigen vakbond oprichten die kan opkomen voor het waarborgen van hun rechten,
     en hun bescherming tegen uitbuiting en erbarmelijke leefomstandigheden.
 
 1.  Nederland zet zich op Europees niveau in voor het afschaffen van FRONTEX en de Dublinverordening.


### PR DESCRIPTION
ingediend door: Andrew Ammerlaan

Het separeren van arbeidsmigranten in een eigen aparte vakbond ondermijnt juist de (internationale) solidariteit die zo essentieel is voor het functioneren van een vakbond. Mensen die werken in een bepaalde sector moeten gewoon lid kunnen worden van een vakbond in die sector, ongeacht of zij wel of niet Nederlands staatsburger zijn. Uiteraard blijft de mogelijkheid voor het oprichten van een eigen vakbond open voor wanneer de arbeidsmigranten in kwestie daar zelf behoefte aan hebben. Daarnaast is het woord “krijgen” verkeerd in de oorspronkelijke tekst, een vakbond wordt opgericht voor en door werknemers, niet “gegeven” door de staat.