### PR TITLE
Centrale rol voor het EP, ipv enkel belangrijkere

### DIFF
--- a/README.md
+++ b/README.md
@@ -1565,7 +1565,7 @@ heeft BIJ1 de volgende kernpunten voor ogen:
     centraal stelt in beleid, wetgeving en budgettering.
 
 1.  De Europese Unie wordt veel democratischer.
-    Het Europees Parlement moet een belangrijkere rol krijgen bij het vormen van beleid.
+    Het Europees Parlement moet de centrale rol krijgen bij het vormen van beleid.
     De Europese Raad, Raad van de Europese Unie, de Europese Commissie
     en andere vormen van onderhandelingen moeten transparant worden.
 


### PR DESCRIPTION
ingediend door: Andrew Ammerlaan

Dit punt is niet sterk genoeg geformuleerd. Het Europees Parlement is het enige daadwerkelijk democratisch gekozen orgaan, en verdient dus *de centrale* rol, niet enkel een meer belangrijke rol dan dat deze nu heeft,