### PR TITLE
Computers mogen nooit beslissingen maken over leven en dood.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1601,8 +1601,9 @@ heeft BIJ1 de volgende kernpunten voor ogen:
     Wie weigert mee te vechten in overzeese oorlogen wordt niet bestraft.
     Er komt (postuum) eerherstel voor dienstweigeraars uit het verleden.
 
-1.  Er komt per direct een stop op het ontwikkelen van AI-systemen voor militaire doeleinden:
-    de ontwikkeling en het gebruik van AI
+1.  Er komt per direct een stop op het ontwikkelen van AI-systemen voor militaire doeleinden.
+    Computers mogen nooit beslissingen maken over leven en dood.
+    De ontwikkeling en het gebruik van AI
     zijn nog altijd doordrongen van discriminerende algoritmes en data.
     In de praktijk leidt dit ertoe dat gemarginaliseerde groepen
     disproportioneel harder worden getroffen


### PR DESCRIPTION
ingediend door: Andrew Ammerlaan

Zelfs al was er een AI die niet ontwikkeld was met behulp van discriminerende algoritmes, dan nog is het onethisch om een computer (ongeacht hoe ‘intelligent’ deze is) te laten beslissen over leven en dood. Dit soort beslissingen dienen altijd door mensen gemaakt te worden.