### PR TITLE
Specificeer dat open access gratis dient te zijn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1832,7 +1832,7 @@ heeft BIJ1 de volgende kernpunten voor ogen:
 
 1.  De invloed van de fossiele industrie op onderwijs en onderzoek moet stoppen.
     Om de macht van academische uitgevers tegen te gaan,
-    moet de overheid investeren in "open access",
+    moet de overheid investeren in gratis "open access",
     door middel van digitale infrastructuur en internationale lobby.
 
 1.  Besturen en raden van toezicht van hogescholen en universiteiten worden democratisch verkozen,


### PR DESCRIPTION
ingediend door: Andrew Ammerlaan

Het grote probleem van veel open access journals is dat de kosten van publicatie verplaatst worden van de lezer naar de schrijver, in andere woorden iemand die open access wilt publiceren draait zelf op voor de misgelopen inkomsten van het journal. De toevoeging van het woord “gratis” is dus belangrijk omdat open access anders iets blijft enkel voor de onderzoekers die dit uit principiële overwegingen per se willen doen en bij een instelling werken die bereid is deze extra kosten te financieren.