### PR TITLE
Voor een investering in duurzame kernenergie

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,13 @@ BIJ1 heeft hiervoor de volgende plannen:
     zodat mensen met lagere inkomens
     niet de rekening gepresenteerd krijgen voor de energietransitie.
 
+1.  Om energiegerelateerde CO2-emissies (serieus) te reduceren investeren we in kernenergie.
+    Deze duurzame, veilige en schone vorm van energie is samen met zon en wind
+    cruciaal voor een stabiele en daarmee goedkope energievoorziening,
+    die ook levert als het niet waait of de zon minder of niet schijnt.
+    Om het kernafval en de noodzaak tot mijnbouw te verkleinen,
+    zetten we in op de bouw van snelle kweekreactoren.
+
 ### Natuur en Vervoer
 
 1.  OV-bedrijven worden genationaliseerd.


### PR DESCRIPTION
ingediend door: Emil Jacobs

Met wind en zon alleen kunnen we onmogelijk volledig in onze energiebehoefte voorzien, want zoveel molens en panelen kunnen we niet kopen en de benodigde batterijenparken bestaan ook niet. Daarnaast is het grondstoftechnisch totaal niet efficiënt, en moeten we dat dus ook niet willen, gezien waar die grondstoffen (vooral de metalen) vandaan worden gehaald en hoe die worden geraffineerd.

Om een beeld te geven hoeveel energie er nodig is: de geschatte energiebehoefte is 700 TWh aan totale energie tegen 2050. De vele duizenden windturbines in de Noordzee die ons tegen 2050 van 70 GW aan stroom gaan leveren, leveren met 275 TWh nog geen 40% van dit totaal.