### PR TITLE
Maatschappelijke zorg toevoegen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,6 +872,11 @@ Daarvoor heeft BIJ1 de volgende kernpunten voor ogen:
     Huisartsen worden opgeleid voor hormoonbehandelingen.
     Daarnaast hoeven trans personen geen diagnose meer te ontvangen om zorg te krijgen.
 
+1.  Maatschappelijke zorg moet weer nationaal gecoördoneerd worden
+    zodat willekeur per gemeente niet meer voorkomt.
+    Alle WMO-ambtenaren moeten extra geschoold worden
+    over validisme, neurodivergentie, en het VN-verdrag Handicap.
+
 ## 7. Aruba, Bonaire, Curaçao, Saba, Statia en Sint Maarten
 
 ### <mark>Radicale Gelijkwaardigheid en Herstel in het Koninkrijk</mark>


### PR DESCRIPTION
ingediend door: Alba Arendsen

De WMO is momenteel door de versnippering een grote inefficiënte validistische chaos waardoor veel mensen die recht hebben op maatschappelijke zorg dat niet krijgen. Niet de voorgestelde tekst letterlijk moet worden toegevoegd, maar een nog nader uit te werken hoofdstukje. Er is namelijk heel veel mis in de maatschappelijke zorg en dat moet ook een plek krijgen in het programma.