### PR TITLE
Verdubbeling van het aantal kamerleden plus kiesdrempel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1890,7 +1890,7 @@ Daarvoor heeft BIJ1 de volgende kernpunten voor ogen:
     meegroeien met het aantal inwoners in Nederland,
     want volksvertegenwoordigers kunnen hun werk alleen goed doen
     wanneer ze voldoende tijd en ondersteuning krijgen.
-    Dat betekent dat het huidige aantal van 150 Kamerleden flink moet worden vergroot.
+    We verdubbelen het huidige aantal van 150 Kamerleden naar 300 Kamerleden, met een kiesdrempel van 2 zetels.
     Ook wordt het budget voor fractiemedewerkers verhoogd.
 
 1.  Het salaris van voltijdsvolksvertegenwoordigers wordt herzien en verlaagd.


### PR DESCRIPTION
ingediend door: Alaa Kalaf (ledenbestand) Ibrahim Hakra (aan leden)

Bij een verdubbeling van het aantal Kamerleden met een kiesdrempel van 2 zetels blijft er effectief niets veranderd. 300:2 en 150:1 is in principe hetzelfde. Een partij zal 1/150 deel van de stemmen moeten winnen om een zetel te krijgen, de huidige kiesdrempel dus. Echter zal de verdubbeling van het aantal Kamerleden wel werkdruk afnemen van Kamerleden en zullen eenmansfracties (met uitzondering van afsplitsingen) niet meer bestaan.