### PR TITLE
We erkennen de ernst van postinfectieuze aandoeningen en investeren in diagnose, behandeling en preventie

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,6 +872,13 @@ Daarvoor heeft BIJ1 de volgende kernpunten voor ogen:
     Huisartsen worden opgeleid voor hormoonbehandelingen.
     Daarnaast hoeven trans personen geen diagnose meer te ontvangen om zorg te krijgen.
 
+1.  Er wordt structureel geïnvesteerd in (biomedisch) onderzoek
+    naar postinfectieuze aandoeningen zoals long covid en ME/CVS.
+    Er komt erkenning van de manier waarop patiënten in de steek zijn gelaten.
+    Passende zorg wordt ingericht, bijvoorbeeld in specialistische poliklinieken.
+    Tevens zal er een voorlichtingscampagne komen over het bestaan en de effecten van deze aandoeningen.
+    Naast diagnose en behandeling wordt ook voorkómen van postinfectieuze aandoeningen een prioriteit.
+
 ## 7. Aruba, Bonaire, Curaçao, Saba, Statia en Sint Maarten
 
 ### <mark>Radicale Gelijkwaardigheid en Herstel in het Koninkrijk</mark>


### PR DESCRIPTION
ingediend door: Maarten Steenhagen

BIJ1 heeft zich de afgelopen kabinetsperiode zichtbaar ingezet voor mensen met long covid en postinfectieuze aandoeningen, en laten zien voor hen te willen vechten (het gaat hier om honderdduizenden mensen in het Koninkrijk). In het nieuwe verkiezingsprogramma moeten we die lijn doorzetten, omdat we tegen hun onderdrukking moeten vechten en omdat veel mensen de partij door onze standpunten over postinfectieuze aandoeningen hebben gevonden. BIJ1 moet hun recht op erkenning en welzijn beschermen en passende eerste- en tweedelijnszorg voorstaan. Deze toevoeging voorziet daar in, en ligt in lijn met het advies van de Gezondheidsraad (2018/07) en met wat ervaringsdeskundigen zeggen: https://tinyurl.com/niethersteld