### PR TITLE
doorbreek de witte schoolbesturen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1787,6 +1787,9 @@ heeft BIJ1 de volgende kernpunten voor ogen:
     Er worden middelen vrijgemaakt voor trainingen aan onderwijsinstellingen
     over racisme, discriminatie en de doorwerking van kolonialisme.
     Daarnaast wordt het makkelijker voor scholieren en studenten om meldingen te maken van racisme en discriminatie.
+    Er komen diversiteitscommissies voor alle basis en middelbare onderwijsinstellingen in onze gemeente.
+    Deze commissies moeten zorgen voor diversiteitsquota in alle onderwijs- en bestuurslagen.
+    Er wordt proactief geworven op diversiteit voor leraren en de onderwijsbestuurslaag.
 
 1.  Bedrijven die discrimineren in hun selectie voor stagiairs worden beboet
     en uitgesloten van overheidsopdrachten en subsidies.


### PR DESCRIPTION
ingediend door: Dorien

Een heel belangrijke oorzaak van onderadvisering en kansenongelijkheid in het onderwijs is de eenzijdige samenstelling van besturen. Lage verwachtingspatronen door racistische, seksistische, klassisistische en validistische vooroordelen zorgen ervoor dat sommige leerlingen minder uitdagend onderwijs krijgen dan hun klasgenoten en een lager schooladvies krijgen