### PR TITLE
Verdubbeling aantal Kamerleden en kiesdrempel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1890,7 +1890,7 @@ Daarvoor heeft BIJ1 de volgende kernpunten voor ogen:
     meegroeien met het aantal inwoners in Nederland,
     want volksvertegenwoordigers kunnen hun werk alleen goed doen
     wanneer ze voldoende tijd en ondersteuning krijgen.
-    Dat betekent dat het huidige aantal van 150 Kamerleden flink moet worden vergroot.
+    We verdubbelen het aantal Tweede Kamerleden naar 300, en we verhogen de kiesdrempel naar 2 zetels.
     Ook wordt het budget voor fractiemedewerkers verhoogd.
 
 1.  Het salaris van voltijdsvolksvertegenwoordigers wordt herzien en verlaagd.


### PR DESCRIPTION
ingediend door: Ibrahim Hakra

Om Kamerleden te ontlasten van een te zware werkdruk is het noodzakelijk om het aantal Kamerleden te verdubbelen. Door de kiesdrempel naar 2 zetels te veranderen behoud je de huidige kiesdrempel van 1/150e deel van de stemmen. Een partij hoeft dus niet meer of minder stemmen te winnen om in de Kamer te komen, dit blijft onveranderd. Wel zorgt het voor minder eenmansfracties (afsplitsingen kunnen natuurlijk nog ontstaan).