### PR TITLE
Automatische inflatiecorrectie

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ Dit doen we op de volgende manieren:
     zodat het structureel meestijgt met andere lonen.
     Het minimumjeugdloon wordt afgeschaft
     en gelijkgetrokken met het minimumloon voor volwassenen.
+    We leggen inflatiecorrectie van de lonen wettelijk vast,
+    zodat de lonen automatisch met de inflatie meestijgen.
 
 1.  Bedrijven en werkplekken worden democratisch bestuurd
     en komen in handen van werknemers in plaats van bedrijfseigenaren.


### PR DESCRIPTION
ingediend door: Ibrahim Hakra

In België is er sprake van automatische inflatiecorrectie. Als de inflatie in 2022 16% is, gaan de lonen op 1 januari 2023 met 16% omhoog. Wij kunnen dit ook, zo neemt de koopkracht niet af dankzij inflatie.