### PR TITLE
Toevoeging Wereldhandelsorganisatie als neokoloniaal instituut

### DIFF
--- a/README.md
+++ b/README.md
@@ -1552,7 +1552,7 @@ heeft BIJ1 de volgende kernpunten voor ogen:
     zodat extreme ongelijkheid en klimaatverandering aangepakt kunnen worden.
 
 1.  Nederland verzet zich tegen het [neokolonialisme](https://bij1.org/woordenlijst/)
-    van internationale ondemocratische instituties zoals de IMF en Wereldbank.
+    van internationale (ondemocratische) instituties zoals het IMF, de Wereldbank, en de Wereldhandelsorganisatie.
     Daarnaast zet Nederland zich internationaal actief in
     voor het kwijtschelden van alle schulden van landen
     die te lijden hebben gehad onder koloniaal bewind.


### PR DESCRIPTION
ingediend door: Juul Seesing

Academici zoals Ha-Joon Chang (in het boek "Bad Samaritans: The Myth of Free Trade and the Secret History of Capitalism") en Jason Hickel (in het boek "The Divide: A Brief Guide to Global Inequality and its Solutions") hebben de Wereldhandelsorganisatie gedefinieerd als een van de drie belangrijkste instituties van neokoloniaal mondiaal economisch bestuur, samen met de Wereldbank en het IMF. Ik ben van mening dat de Wereldhandelsorganisatie in deze context ook vermeld moet worden.

Ik heb twee haakjes rondom "ondemocratische" gezet, omdat de Wereldhandelsorganisatie technisch gezien democratisch is met één stem voor ieder land: in de praktijk blijkt echter dat rijke landen vrijwel altijd hun zin krijgen.