### PR TITLE
Geen bestaanszekerheid, bestaansrecht

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Hiervoor heeft BIJ1 de volgende kernpunten voor ogen:
     en 18 maart (Dia di Himno y Bandera, de Arubaanse Dag van het Volkslied en de Vlag)
     worden nationale feestdagen.
 
-## 2. Werk En Bestaanszekerheid
+## 2. Werk En Bestaansrecht
 
 ### <mark>Alles is Altijd al van Ons</mark>
 
@@ -180,6 +180,12 @@ mantelzorg en vrijwilligerswerk is van onschatbare waarde voor onze maatschappij
 onze economie zou niet kunnen draaien zonder.
 Het is tijd dat we niet langer onderscheid maken
 tussen welk werk we wel en niet waarderen of belonen.
+In de grondwet staat dat 'discriminatie … welke grond dan ook' niet is toegestaan,
+en wij als partij vinden dat voor eerste levensbehoeften
+niet gediscrimineerd mag worden op inkomen of kapitaal.
+Mensen hebben het recht op bestaanszekerheid,
+dus moet de overheid bestaansrecht garanderen.
+Wij als Bij1 vechten daarvoor
 </strong>
 
 We moeten ruimte maken voor de grote diversiteit aan vormen waarop mensen hun leven inrichten,


### PR DESCRIPTION
ingediend door: Jozef van de Visse

Bestaanszekerheid is niet genoeg, als radicale partij opgericht voor gelijkheid voor iedereen moeten wij om meer vragen. Pieter Omtzigt en Willem-Alexander van Amsberg praten over bestaanszekerheid, wij moeten praten over bestaansrecht.

Men hoort niet alleen zeker te zijn van kunnen voortleven, basale levensbehoeften moeten een recht zijn.

Wij geven daarom de suggestie de volgende clausule op te nemen (waar nodig in omgeschreven vorm) in onderdeel 2 van het partijprogramma.

"In de grondwet staat dat 'discriminatie … welke grond dan ook' niet is toegestaan, en wij als partij vinden dat voor eerste levensbehoeften niet gediscrimineerd mag worden op inkomen of kapitaal. Mensen hebben het recht op bestaanszekerheid, dus moet de overheid bestaansrecht garanderen. Wij als Bij1 vechten daarvoor"

en daarnaast alle keren dat "bestaanszekerheid" genoemd wordt "bestaansrecht" in de plaats daarvan te gebruiken.