### PR TITLE
Sluit Rotterdam The Hague Airport!

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,8 @@ BIJ1 heeft hiervoor de volgende plannen:
     en is uiterlijk in 2030 volledig elektrisch.
 
 1.  Nederlandse vliegvelden, waaronder Schiphol, mogen niet verder uitbreiden.
+    Er komt geen vierde aanvliegroute voor Schiphol,
+    Lelystad Airport opent niet en Rotterdam The Hague Airport wordt gesloten.
     Er komt BTW en accijns op kerosine,
     en we zetten ons op Europees niveau in om zo snel mogelijk
     op duurzame wijze een Europees spoornetwerk te realiseren.


### PR DESCRIPTION
ingediend door: Renske & Akef

We zijn blij dat in het programma wordt benoemd dat vliegvelden niet mogen groeien. We zien graag dat dit een stap verder gaat, en als radicaal voorstel onder meer het sluiten van Rotterdam The Hague Airport (RTHA).