### PR TITLE
Geen enkel kind in volwassenenstrafrecht!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1424,6 +1424,8 @@ Hiervoor heeft BIJ1 de volgende kernpunten voor ogen:
     zodat daders menswaardig worden behandeld.
     De voorwaarden om voor vervroegde vrijlating in aanmerking te komen worden versoepeld.
 
+1.  Het volwassenenstrafrecht wordt nooit toegepast op kinderen onder de 18.
+
 ### Van Politiecontrole naar Controle over de Politie
 
 1.  De politie mag niet langer aanwezig zijn op campussen


### PR DESCRIPTION
ingediend door: Renske & Akef

Rechters kunnen ervoor kiezen om 16 en 17 jarigen als volwassenen te behandelen in het strafrecht. BIJ1 wil een wereld zonder strafrecht. Tot die tijd moeten alle minderjarigen ook als minderjarige worden behandeld.