### PR TITLE
Verhoog de minimumleeftijd voor strafrechtelijke aansprakelijkheid naar 14 jaar!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1424,6 +1424,8 @@ Hiervoor heeft BIJ1 de volgende kernpunten voor ogen:
     zodat daders menswaardig worden behandeld.
     De voorwaarden om voor vervroegde vrijlating in aanmerking te komen worden versoepeld.
 
+1.  De wettelijke leeftijd voor strafrechtelijke aansprakelijkheid wordt verhoogd naar minimaal 14 jaar.
+
 ### Van Politiecontrole naar Controle over de Politie
 
 1.  De politie mag niet langer aanwezig zijn op campussen


### PR DESCRIPTION
ingediend door: Renske & Akef

In Nederland zijn kinderen vanaf 12 jaar strafrechtelijk aansprakelijk. BIJ1 wilt een wereld zonder strafrecht. Tot die tijd moeten in ieder geval kinderen zo jong als 12 en 13 niet strafrechtelijk aansprakelijk zijn.