### PR TITLE
Van genderneutraal naar gendersensitief: neem femicide op in het strafrecht!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1424,6 +1424,11 @@ Hiervoor heeft BIJ1 de volgende kernpunten voor ogen:
     zodat daders menswaardig worden behandeld.
     De voorwaarden om voor vervroegde vrijlating in aanmerking te komen worden versoepeld.
 
+1.  Femicide wordt, met inzet van expertisecentra als Atria en Movisie,
+    breed gedefinieerd en opgenomen in het Wetboek van Strafrecht.
+    Genderspecifieke data wordt verzameld om genderverschillen te erkennen
+    en mee te overwegen in verdere beleid.
+
 ### Van Politiecontrole naar Controle over de Politie
 
 1.  De politie mag niet langer aanwezig zijn op campussen


### PR DESCRIPTION
ingediend door: Renske & Akef

Femicide, de meest extreme vorm van gendergerelateerd geweld, wordt in Nederland niet specifiek genoemd binnen de wetgeving. Er is geen definitie van dit fenomeen opgenomen in het Wetboek van Strafrecht. Femicide valt onder genderneutrale bepalingen van het Nederlands strafrecht, zoals doodslag en moord. Het ontbreken van een wettelijk kader bemoeilijkt de juiste documentatie en registratie van de moorden op vrouwen. Femicidezaken worden daarom nog te vaak weggezet als individuele casussen. Een gendersensitieve aanpak is daarom van belang: een analyse van beleid in Nederland wijst uit dat genderneutrale beleidsmaatregelen het structurele karakter van dit soort geweld negeren.