### PR TITLE
De Maas ook specifiek benoemen als rechtspersoon

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ BIJ1 heeft hiervoor de volgende plannen:
     Er komt een nationaal bomenplan om het aantal bomen in Nederlandse steden fors uit te breiden.
     Belangrijke ecosystemen, natuurgebieden en wilde dieren
     moeten rechten krijgen om bescherming, behoud (en eventueel herstel) te waarborgen.
-    De Waddenzee moet als eerste als zelfstandige rechtspersoonlijkheid aangemerkt worden.
+    De Waddenzee en de Maas moeten als eerste zelfstandige rechtspersoonlijkheden aangemerkt worden.
 
 ### Internationale Klimaatrechtvaardigheid
 


### PR DESCRIPTION
ingediend door: Emiel Derckx

Groepen zijn al geruime tijd bezig de Maas als eerste rivier een rechtspersoon te maken. Het is van belang de Maas hierom ook specifiek te benoemen.

De Maas is op dit moment te erg vervuild, maar speelt wel een cruciale rol in de watervoorziening van Nederland (in totaal zijn 7 miljoen mensen afhankelijk van de Maas).

Informatie om van de Maas een rechtspersoon te maken:
- https://maascleanup.nl/artikel/artikel-een-schonere-rivier-begint-met-een-maas-in-de-wet-door-peter-bruijns/

- https://www.oneworld.nl/klimaat/deze-limburgers-willen-dat-de-maas-rechten-krijgt/

Recent nieuwsbericht over vervuiling:
- https://nos.nl/artikel/2490054-waterbedrijven-maas-wordt-viezer-door-lozingen-en-klimaatverandering