### PR TITLE
vluchtelingenkinderen tussen wal en schip in het onderwijs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1770,6 +1770,11 @@ heeft BIJ1 de volgende kernpunten voor ogen:
     en scholengemeenschappen met verschillende schoolsoorten (vmbo, havo, vwo).
     Diploma's in het voortgezet onderwijs moeten gestapeld kunnen worden zonder aanvullende eisen.
 
+1.  kinderen en jongeren die later instappen in het Nederlandse onderwijs
+    of jaren onderwijs door omstandigheden moeten missen,
+    krijgen voldoende tijd om Nederlands te leren en/of onderwijsjaren in het halen
+    in schakelonderwijs met maatwerk, zonder beperking in tijd of leeftijd
+
 1.  Er wordt geen lesmateriaal meer gebruikt
     waarin een eenzijdig en eurocentrisch verhaal over de geschiedenis wordt gepresenteerd.
     Scholen stoppen onmiddellijk met het gebruik van lesmateriaal


### PR DESCRIPTION
ingediend door: Dorien Ballout

Veel kinderen en jongeren op de vlucht vallen tussen wal en schip omdat zij door de vluchtjaren pas op veel latere leeftijd met school kunnen beginnen (en ook nog eerst een nieuwe taal moeten leren daarvoor) of jaren hebben gemist in vergelijking met leeftijdgenoten. Nu krijgen ze daarvoor 2 jaar de tijd en dan moeten ze op basis van leeftijd instappen in het reguliere onderwijs. (en dan moeten ze bijvoorbeeld na maar 2 jaar basisonderwijs te hebben gehad naar het middelbare onderwijs met een schooladvies voor praktijkonderwijs) of ze bereiken dan al snel de niet-leerplichtige leeftijd en dan wordt het heel moeilijk om nog een middelbare schooldiploma te halen of aan een passende vervolgopleiding te beginnen.