### PR TITLE
Onderzoeken altijd binnen hetzelfde punt verbinden met het doel of nut van dat onderzoek. Onderzoeken zelf zijn geen actie van anti-discriminatie.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1315,7 +1315,8 @@ heeft BIJ1 de volgende kernpunten voor ogen:
     met structurele oplossingen voor knellende wetgeving.
 
 1.  Er wordt onderzoek gedaan naar hoe gender, etniciteit en seksualiteit
-    invloed hebben op het leven en welzijn van mensen met een beperking.
+    invloed hebben op het leven en welzijn van mensen met een beperking
+    om zo wetgeving, beleid en infrastructuur te vormen wat de toegankelijkheid bevorderd.
 
 1.  Gemeentebeleid dat mensen met een beperking raakt wordt landelijk vastgelegd.
     Zo kunnen mensen in elke gemeente aanspraak maken


### PR DESCRIPTION
ingediend door: Liyah Park

Onderzoeken zijn nu enorme kosten posten en geven vaak informatie die al beschikbaar of eerder geïnventariseerd is. Onderzoeken worden gedaan door enorme (witte) consultancy/ marketing bureaus, waardoor die begrotingen die worden gedaan ten behoeve van anti-discriminatie uiteindelijke niet bij de gemarginaliseerde groepen aankomt. Wanneer we spreken van onderzoek in ons programma; moeten we altijd duidelijk in hetzelfde punt dit linken aan een bepaalde actie / doel. Onderzoeken zijn 'non-performatives' als ze op zichzelf staan.