### PR TITLE
De wet moet veranderen, wanneer men te veel huur heeft betaald, moet deze die het altijd terug kunnen krijgen en verhuurders moeten beboet worden.

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,13 @@ heeft BIJ1 de volgende plannen:
     Er wordt een verhuurvergunning met strenge kwalificatie-eisen ingevoerd
     en er wordt geïnvesteerd in de controlediensten van de gemeenten die hierop moeten toezien.
 
+1.  Het tijdslimiet van 2 jaar op het toetsen en dus kunnen terugeisen van het te veel betaalde aanvangshuur vervalt.
+    Tijdens het bewonen en voor een periode die gelijkt staat aan de tijd dat de oud-bewoner een huurcontract heeft gehad,
+    mag deze na het verlaten van de woning te veel betaalde huur terug eisen.
+    Verhuurders zijn verplicht na een periode van 5 jaar
+    bij een nieuwe bewoner de woning te toetsen met het punten systeem.
+    Deze informatie staat verplicht in elk huurcontract.
+
 1.  Huurcontracten voor onbepaalde tijd worden de standaard en
     ook private huur krijgt een huurplafond gebaseerd op een eerlijk puntenstelsel,
     waarin de kwaliteit van de woning wordt meegenomen.


### PR DESCRIPTION
ingediend door: Liyah

De verantwoordelijkheid van het toetsen van de (aanvangs-)huurprijs ligt nu bij de huurder. Daar de meest gemarginaliseerde mensen vaak niet op de hoogte zijn van hun rechten, moeten wij ervoor zorgen dat we een systeem bouwen wat een preventieve insteek heeft. Daarnaast kan men nu alleen nog binnen 2 jaar teveel betaalde huur terug krijgen, dat moet veranderen en gelijk zijn aan de duur van het (verlopen of huidige) huurcontract.

Sprekend uit ervaring van iemand die 7 jaar lang teveel huur heeft betaald en kon zwaaien naar der geld en mijn verhuurder ongestraft verder kan met zijn leven. Ik moest maar blij zijn met een huurverlaging, die eigenlijk vanaf dag 1 al zo had moeten zijn.

We kunnen niet van mensen verwachten dat ze bijna een halve rechtenstudie doen om elke hoek van beleid te kennen.