### PR TITLE
Toevoegen dat de BMI beoordeling voor medische zorg (inc trans zorg) wordt geschrapt uit alle vormen van zorg. Artsen die deze alsnog gebruiken worden aangeklaagd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,8 @@ Daarvoor heeft BIJ1 de volgende kernpunten voor ogen:
     Er wordt meer geïnvesteerd in onderzoek
     naar ziektebeelden, geneesmiddelen en behandelmethoden
     bij niet-witte mensen, vrouwen en niet-witte vrouwen.
+    De BMI als beoordeling voor het toezeggen van medische ingrepen (inclusief transzorg) wordt afgeschaft.
+    Artsen en verzekeringen die gebruik maken van deze verzonnen methode worden beboet.
 
 1.  In de opleiding van artsen, hulpverleners, thuis- en ouderenzorg en medisch personeel
     komt meer aandacht voor de bestrijding van racistische stereotypen.


### PR DESCRIPTION
ingediend door: Liyah Park

BMI is racisme and that's on period. Het is onwetenschappelijk wat al jaren lang bekend is. Mensen van kleur en dikke mensen zijn hier het meest slachtoffer van. I'm not even going to explain.

BMI is racisme en dat moet wettelijk aangepast worden. purr