### PR TITLE
We veroordelen de Russische agressieoorlog in Oekraïne

### DIFF
--- a/README.md
+++ b/README.md
@@ -1590,10 +1590,16 @@ heeft BIJ1 de volgende kernpunten voor ogen:
     Er komen ruimhartige genoegdoening en herstelbetalingen
     aan slachtoffers van Nederlandse overzeese militaire acties.
 
-1.  Nederland zet zich in voor een eind aan de invasie door Rusland in Oekraïne.
-    Nederland doet dit door humanitaire hulp
-    en het toezien op naleving van het humanitair recht.
-    Nederland stopt met het sturen van wapens en stuurt aan op een staakt-het-vuren.
+1.  We veroordelen de imperialistische agressieoorlog van Rusland tegen Oekraïne.
+    Nederland zal ruimhartig humanitaire hulp aan Oekraïne blijven bieden zo lang als nodig is
+    en ook bijdragen aan de wederopbouw van Oekraïne wanneer de oorlog is beëindigd.
+    Hierbij zal Nederland zich inzetten om alle internationale schulden van Oekraïne te vergeven.
+    Nederland zal staakt-het-vuren faciliteren en, waar er ruimte is,
+    diplomatie en onderhandelingen ondersteunen met oog voor de behoeften en wensen van de Oekraïners.
+    Nederland zet zich in om Poetin en andere leiders juridisch ter verantwoording te roepen
+    voor schendingen van mensenrechten, oorlogsmisdrijven, misdrijven tegen de menselijkheid
+    en het plannen en uitvoeren van een agressieoorlog tegen Oekraïne.
+    Ook steunt Nederland Russische dissidenten en activisten die zich verzetten tegen de oorlog.
 
 1.  We krimpen onze krijgsmacht in om uiteindelijk de krijgsmacht te vervangen door een civiele hulporganisatie.
     Tot die tijd moet de krijgsmacht doordrongen zijn van anti-racistische en democratische waarden.


### PR DESCRIPTION
ingediend door: Martijn Dekker

De huidige tekst over de Russische oorlog doet onvoldoende recht aan de situatie.

BIJ1 heeft hier ideologisch een visie op: Rusland voert een imperialistische agressieoorlog tegen een buurland. We zijn het onszelf verplicht dit te benoemen, ongeacht wie de dader is. En daarom moeten we dit veroordelen als we erover schrijven.

En hoe dan ook, Oekraïne is het slachtoffer. Enkel 'humanitaire hulp' dekt niet wat we nu en later kunnen doen om Oekraïners te helpen, daders (de Russische leiders) ter verantwoording te roepen en Russische activisten te steunen. Deze wijziging verduidelijkt onze bereidheid tot hulp, vervolging en diplomatie.

Tenslotte is het politiek zeer onhandig om hier te noemen dat we stoppen met sturen van wapens. Elk land heeft het recht om zichzelf te verdedigen, dat vergt nu eenmaal wapentuig. Tegelijkertijd is het BIJ1 standpunt over de wapenindustrie helder. Maar de huidige tekst doet het lijken alsof één land (Oekraïne) wapens ontzegd moet worden, terwijl de ander (Rusland) door blijft bombarderen. Op die manier trek je in feite de agressor voor, en dat is niet ons standpunt over oorlog.

Tevens zal de huidige tekst misbruikt kunnen worden om onze standpunten over oorlog te verdraaien. Dat moeten we voorkomen. Het is in dit geval verstandig om de aandacht te richten op alle dingen die wel willen doen, in plaats van hetgeen we niet willen.