### PR TITLE
Schrappen erkenning Molukken en strijd West-Papoea

### DIFF
--- a/README.md
+++ b/README.md
@@ -1522,7 +1522,6 @@ heeft BIJ1 de volgende kernpunten voor ogen:
 
 1.  [Dekolonisatie](https://bij1.org/woordenlijst/), emancipatie, en zelfbeschikking van volkeren
     geldt als uitgangspunt bij erkenning van nieuwe staten.
-    Nederland erkent de Republik Maluku Selatan en steunt de onafhankelijkheidsstrijd van West-Papoea.
 
 1.  We maken een einde aan de bezetting en kolonisatie van Palestijns grond en het Palestijnse volk.
     Palestijnse vluchtelingen moeten het recht hebben op terugkeer naar hun huizen en bezittingen.


### PR DESCRIPTION
ingediend door: Ibrahim Hakra

BIJ1 hoeft niet de rol van Nederland als internationale politieagent door te zetten. Binnen BIJ1 is er nog lang niet genoeg onderwijs over het onderwerp van Indonesië, de Molukken, etc. Het is niet aan Nederland om landen in het globale zuiden te erkennen en landen op te splitsen, BIJ1 is geen CIA.