### PR TITLE
Vergoeden van ivf kosten queer stellen of andere gezinsvormen, toestaan van eicel donatie bij autisme en erfelijke aandoeningen die het leven niet aantasten

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,13 @@ Daarvoor heeft BIJ1 de volgende kernpunten voor ogen:
     Zij moeten vanuit eigen regie toegang hebben
     tot een passend en samenhangend pakket aan zorg en ondersteuning.
 
+1.  IVF volledig vergoed onder de basis verzekering ongeacht gender en gezinssamenstelling
+
+1.  mensen met een beperking, autisme of overige erfelijke aandoeningen —
+    die in een wereld vrij van validisme —
+    de menswaardigheid van een persoon niet aantasten in het dagelijks leven,
+    mogen ook eicellen doneren en gebruik maken van IVF.
+
 ### Laat de Zorg weer Werken
 
 1.  Huisartsenpraktijken worden zorgcentra in de wijk,


### PR DESCRIPTION
ingediend door: Liyah Park

- stellen die niet zonder medische hulpmiddelen een kind kunnen krijgen én niet man/vrouw zijn met vruchtbaarheidsproblemen, moeten nu nog veel kosten zelf betalen zoals kosten voor een spermadonor of andere behandelingen. Vaak wijken mensen daardoor uit naar buurlanden voor deze zorg
- mensen met autisme ervaren veel discriminatie bij het willen doneren van eicellen. Dit is een vorm van medische discriminatie. Zie ook: https://www.thebestsocial.media/nl/discriminatie-mensen-met-autisme/amp/