### PR TITLE
Toegankelijkheid, inclusie en welzijn toevoegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1351,6 +1351,22 @@ heeft BIJ1 de volgende kernpunten voor ogen:
 1.  Informatie van de overheid wordt standaard toegankelijk gemaakt,
     in begrijpelijke taal en beschikbaar in braille.
 
+### Toegankelijkheid, Inclusie en Welzijn
+
+1.  Er komt structureel meer geld voor passende dagelijkse ondersteuning voor mensen met een beperking.
+    Toekenning van het persoonsgebonden budget (PGB) wordt gelijkwaardiger en laagdrempeliger.
+    De uitvoering van de Wet maatschappelijke ondersteuning (Wmo) wordt weer op landelijk niveau gecoördineerd
+    en de eigen bijdrage verdwijnt.
+
+1.  Stigmatisering op basis van gezondheid wordt tegengegaan
+    en het gebruiken van persoonlijke hulp- en beschermingsmiddelen
+    zoals orthesen, mondneusmaskers of gehoorbeschermers
+    wordt ondersteund, ook op het werk en op school.
+
+1.  We zetten ons in voor een inclusieve sport- en cultuursector,
+    en maken extra geld vrij om sport en culturele activiteiten
+    toegankelijker te maken voor mensen met een beperking.
+
 ## 11. Veiligheid en Justitie
 
 ### <mark>Bestaanszekerheid Boven Repressie</mark>


### PR DESCRIPTION
ingediend door: Maarten Steenhagen

Het hoofdstuk 10. TOEGANKELIJKHEID EN INCLUSIE dekt in het conceptprogramma slechts de rechtspositie van mensen met een beperking en aanpassingen aan de openbare ruimte. Maar validisme bemoeilijkt ook alledaagse maatschappelijke deelname. Daarom moet ook het algemeen welzijn van mensen met een beperking in ons programma aan bod komen. Deze toevoeging voorziet hierin door een drietal belangrijke thema's op te nemen (ondersteuning, stigmatisering en sport/cultuur).