### PR TITLE
Vergoeding afbouw medicatie nu!

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,6 +872,14 @@ Daarvoor heeft BIJ1 de volgende kernpunten voor ogen:
     Huisartsen worden opgeleid voor hormoonbehandelingen.
     Daarnaast hoeven trans personen geen diagnose meer te ontvangen om zorg te krijgen.
 
+1.  Wij zetten ons in voor het per direct opnemen van een vergoeding
+    voor afbouwmedicatie doormiddel van de taperingstrip.
+    Dit is een bewezen effectieve methode om veilig (hyperbool) psychofarmaca af te bouwen.
+    Dit zal langdurige gezondheidswinst opleveren voor vele Nederlanders, langdurige zorgkosten drukken
+    en zal een positief effect hebben op de hoeveelheid medicijnresten in het oppervlakte water.
+    Daarnaast gaan wij ervoor zorgen dat medicatie afbouwen en GGZ behandelingen positief afsluiten
+    worden opgenomen in het curriculum van alle hulpverleners.
+
 ## 7. Aruba, Bonaire, Curaçao, Saba, Statia en Sint Maarten
 
 ### <mark>Radicale Gelijkwaardigheid en Herstel in het Koninkrijk</mark>


### PR DESCRIPTION
ingediend door: Dien Winkel

Op dit moment word afbouw medicatie niet vergoed. Pharmaceuten produceren pillen die een te hoge dosis hebben om veilig mee af te bouwen, dit moet namelijk met zeer kleine stapjes. De enige manier om aan een kleinere dosis te komen (zonder zelf te prutsen met pillen snijden of capsules openen) is om een speciale apotheek bereiding aan te vragen, dit kan bij de Regenboog Apotheek in Bavel in de vorm van een taperingstrip. Deze vorm van afbouw medicatie word niet vergoed terwijl een strip van 28 dagen gemiddeld 100eu kost. Oneerlijk en iets waar zo snel mogelijk verandering in moet komen, langdurig medicijngebruik of te snel met te grote stappen afbouwen kan namelijk heftige iatrogene schade veroorzaken. Denk daarbij aan oa. tardieve dyskinesie.