### PR TITLE
Wijzig internationale armoedebestrijding naar ontwikkelingssamenwerking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1537,7 +1537,7 @@ heeft BIJ1 de volgende kernpunten voor ogen:
     zowel binnen als buiten Nederland.
     We verbinden consequenties aan het niet naleven van deze richtlijnen.
 
-1.  Het budget voor internationale armoedebestrijding
+1.  Het budget voor internationale ontwikkelingssamenwerking
     wordt opgehoogd tot 1% van het Bruto Nationaal Product (BNP).
     Het beschermen van mensenrechten en het wereldwijd behalen van de SDG's
     staat centraal in ons buitenlandbeleid.


### PR DESCRIPTION
ingediend door: Chiara

Dit punt is gebaseerd op de oude doelstelling waarin landen afgesproken hebben 0,7% van hun BNP te investeren in internationale ontwikkelingssamenwerking. BIJ1 wil dat dit meer is en wil daarom dit budget verhogen naar 1%. Momenteel wordt ongeveer 20% van het budget voor ontwikkelingssamenwerking gebruikt voor armoede bestrijding. Door meer te investeren in ontwikkelingssamenwerking is er automatisch ook meer budget voor het internationale armoedebestrijding.