### PR TITLE
niet-witte mensen én vrouwen buitengesloten in onderzoeken

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Hiervoor heeft BIJ1 de volgende kernpunten voor ogen:
     Het effect van racisme in de zorg wordt uitgebreid onderzocht en bestreden,
     zowel in de vorm van vooroordelen van zorgmedewerkers
     als behandelsmethoden die gebaseerd zijn op onderzoek
-    waarin niet-witte mensen worden buitengesloten.
+    waarin niet-witte mensen en vrouwen ondervertegenwoordigd zijn.
 
 1.  Er komt een daadkrachtige aanpak tegen Islamofobie en Moslimhaat,
     die na een jarenlange hetze tegen moslims inmiddels zijn genormaliseerd.


### PR DESCRIPTION
ingediend door: Mervyn

Ook vrouwen zijn in onderzoeken voor behandelmethoden ondervertegenwoordigd. Ondervertegenwoordigd is een passender woord dan uitgesloten.