### PR TITLE
migratiebeperkingen zijn racistisch

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Hiervoor heeft BIJ1 de volgende kernpunten voor ogen:
     doen grondig onderzoek naar racisme binnen hun organisaties en functioneren,
     en voeren actief antiracistisch beleid.
 
+1.  We pakken discriminatie in het migratiebeleid aan.
+    Europees en Nederlands migratiebeleid discrimineert op basis van afkomst en klasse.
+    Mensen uit voornamelijk Azie en Afrika toegang tot Europa ontzeggen is neokoloniaal en racistisch.
+    Discriminatie op basis van nationaliteit of verblijfsstatus wordt verboden.
+
 1.  We pakken racisme in wonen en omgeving aan.
     Er zijn talloze onderzoeken uitgevoerd naar discriminatie op de woningmarkt.
     Het is tijd om op basis daarvan antiracistisch beleid vorm te geven,


### PR DESCRIPTION
ingediend door: Pleun Westendorp

Migratie hoort ook onder het kopje ‘anti-racisme en dekolonisatie’ thuis. Migratiebeleid is een legale manier om te discimineren op basis van inkomen en afkomst, en het hangt nauw samen met neokolonialisme. Het is een manier om delen van de wereld arm en makkelijk uitbuitbaar te houden, de bewegingsvrijheid van de global majority ernstig in te perken en om Europa rijk en wit te houden. We kunnen niet strijden tegen racisme zonder het migratiebeleid te zien voor wat het is: een neokoloniaal systeem van Apartheid.