### PR TITLE
alle vluchtelingen welkom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,7 +1032,10 @@ Dit doen we op de volgende manieren:
     We pleiten in EU-verband voor onmiddellijke opzegging van dit soort deals,
     en sluiten ook geen nieuwe migratiedeals.
 
-1.  Nederland hervestigt jaarlijks een groeiend aantal kwetsbare vluchtelingen uit vluchtelingenkampen.
+1.  Alle vluchtelingen zijn welkom.
+    Mensen die aanspraak willen maken op vluchtstatus
+    kunnen bij Nederlandse ambassades een aanvraag indienen.
+    Er komt geen maximum aantal aanvragen en inwilligingen.
 
 1.  Asielzoekers mogen tijdens hun procedure werk zoeken en een studie beginnen.
     Ook ongedocumenteerde mensen mogen werken en studeren.


### PR DESCRIPTION
ingediend door: Pleun Westendorp

op dit moment worden er 500 vluchtelingen per jaar hervestigd. Een toename kan dus ook zijn: 550 vluchtelingen per jaar, dat is veel te weinig. Door te kiezen voor ‘kwetsbaar’ besluit de politieke wind van het moment wie hier wel en niet heen mag komen (een paar jaar geleden werden trans mensen nog nauwelijks erkend of beschermd, en hadden zij dus ook moeilijk aanspraak kunnen maken op hervestiging) en wordt miskend dat ieder mens die geen bestaansrecht heeft in het land van verblijf kwetsbaar gemaakt wordt. Ongeveer de helft van de vluchtelingen woont niet in een kamp, maar bijvoorbeeld in sloppenwijken. Zij zouden met de originele formulering niet in aanmerking komen. Door mensen zelf de mogelijkheid te geven om een aanvraag te doen het aantal aanvragen onbeperkt te maken, is hun behoefte leidend. Niet onze bereidheid om mensen al dan niet te verwelkomen.