### PR TITLE
Smokkelen wordt gedecriminaliseerd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,8 @@ Dit doen we op de volgende manieren:
     wonen is een recht van iedereen.
     Crisiscentra worden gesloten.
 
+1.  Smokkelen wordt gedecriminaliseerd.
+
 1.  De Afdeling Vreemdelingenpolitie, Identificatie en Mensenhandel (vroeger Vreemdelingenpolitie genoemd)
     doet niet langer onderzoek naar de identiteit en de verblijfsrechtelijke status van asielzoekers,
     maar wordt omgevormd tot een taskforce die zich enkel nog bezighoudt


### PR DESCRIPTION
ingediend door: Pleun Westendorp

Grenzen doden, niet smokkelaars. Een smokkelaar biedt een dienst aan, waar iemand die grenzen over wil steken vrijwillig en vaak tegen betaling gebruik van maakt. Omdat er geen veilige vluchtroutes zijn, is dit voor veel mensen de enige manier om te verhuizen. Er zijn natuurlijk slechte smokkelaars, maar veel mensen die nu in Europa leven hebben dat te danken aan hun smokkelaar. Smokkelaars ondermijnen het huidige migratiesysteem. Criminalisering maakt de routes alleen maar gevaarlijker en dodelijker.