### PR TITLE
Koppelingswet afschaffen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1097,6 +1097,10 @@ Dit doen we op de volgende manieren:
     en ongedocumenteerde mensen die zich in Nederland bevinden.
     Hierbij wordt speciaal aandacht besteed aan ongedocumenteerde mensen uit de voormalige koloniën, zoals Suriname.
 
+1.  De Koppelingswet die ongedocumenteerden toegang beperkt of ontzegt
+    tot zorg, onderwijs, onderdak, werk en nog veel meer levensbehoeften, schaffen we af.
+    Ongedocumenteerden worden niet gesegregeerd, maar juist verwelkomd en gelijk behandeld.
+
 1.  Nederland verleent verblijfsrecht aan staatlozen in Nederland
     door hen een Nederlands of staatloosheidspaspoort te geven.
 


### PR DESCRIPTION
ingediend door: Pleun Westendorp

De Koppelingswet is de belangrijkste wet die segregatie van ongedocumenteerden mogelijk maakt en hen rechteloos maakt in Nederland. De wet moet in zijn geheel afgeschaft worden.