### PR TITLE
staatsloosheid maakt iemand nog steeds tweederangsburger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,7 +1098,7 @@ Dit doen we op de volgende manieren:
     Hierbij wordt speciaal aandacht besteed aan ongedocumenteerde mensen uit de voormalige koloniën, zoals Suriname.
 
 1.  Nederland verleent verblijfsrecht aan staatlozen in Nederland
-    door hen een Nederlands of staatloosheidspaspoort te geven.
+    door hen een Nederlands paspoort te geven.
 
 1.  Niemand komt in vreemdelingenbewaring.
     Alle detentiecentra voor uitgeprocedeerde asielzoekers en ongedocumenteerde mensen worden gesloten,


### PR DESCRIPTION
ingediend door: Pleun Westendorp

Een staatsloosheidspaspoort is niet vergelijkbaar met de Nederlandse nationaliteit, hierdoor zouden mensen nog steeds een tweederangsburger zijn. Mensen die geen nationaliteit hebben horen gewoon de Nederlandse nationaliteit te krijgen.