### PR TITLE
Medebewoners houden recht op de woning na overlijden huurder

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,9 @@ heeft BIJ1 de volgende plannen:
     ambtenaren, stagiairs en anderen uit Nederland,
     ten koste van de inwoners van de eilanden, wordt tegengegaan.
 
+1.  Medebewoners in een huurwoning krijgen het recht
+    om in de woning te blijven wonen na overlijden van de huurder van de woning.
+
 ### Een Toegankelijke, Inclusieve en Groene Woonomgeving
 
 1.  Zo veel mogelijk nieuwbouw- en bestaande woningen

--- a/README.md
+++ b/README.md
@@ -1037,10 +1037,6 @@ Dit doen we op de volgende manieren:
 1.  Asielzoekers mogen tijdens hun procedure werk zoeken en een studie beginnen.
     Ook ongedocumenteerde mensen mogen werken en studeren.
 
-1.  Mensen die een werkvisum of tewerkstellingsvergunning hebben,
-    mogen overal werken, dus niet bij 1 werkgever.
-    Zo voorkomen we een machtspositie en mogelijke uitbuiting door de werkgever.
-
 1.  Er komt structurele doorstroom van AZC's naar vaste woningen:
     wonen is een recht van iedereen.
     Crisiscentra worden gesloten.


### PR DESCRIPTION
ingediend door: Mervyn

Het is nu schrijnend dat jongvolwassen kinderen, niet geregistreerde partners, familieleden, mantelzorgers die niet als medehuurder zijn/kunnen worden ingeschreven geen recht hebben op de woning na overlijden van de huurder.