### PR TITLE
Voorwaarden aan relaties binnen wet voor meerouderschap moeten losgelaten worden

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,10 +1037,6 @@ Dit doen we op de volgende manieren:
 1.  Asielzoekers mogen tijdens hun procedure werk zoeken en een studie beginnen.
     Ook ongedocumenteerde mensen mogen werken en studeren.
 
-1.  Mensen die een werkvisum of tewerkstellingsvergunning hebben,
-    mogen overal werken, dus niet bij 1 werkgever.
-    Zo voorkomen we een machtspositie en mogelijke uitbuiting door de werkgever.
-
 1.  Er komt structurele doorstroom van AZC's naar vaste woningen:
     wonen is een recht van iedereen.
     Crisiscentra worden gesloten.

--- a/README.md
+++ b/README.md
@@ -1215,8 +1215,10 @@ stelt BIJ1 de volgende beleidsveranderingen voor:
 
 1.  Er komt een wet voor meerouderschap.
     Het huidige huwelijksrecht en samenlevingsrecht worden op zo'n manier aangepast,
-    dat er gelijke sociale en financiële rechten worden geboden
-    aan alle gezinnen, samenwonenden en samenlevenden.
+    dat alle mensen (of relaties) die meervoudig ouderschap verkiezen
+    gelijke sociale en financiële rechten verkrijgen.
+    De overheid stelt geen voorwaarden aan de vorm van de relatie
+    waarbinnen mensen meervoudig ouderschap verkiezen.
 
 1.  Er wordt een einde gemaakt aan interlandelijke adoptie.
 


### PR DESCRIPTION
ingediend door: Ilona Hartlief

Begrip 'gezin' vermijden, omdat het sterk gelinkt is met heteronormatieve ideeën hoe (meer)ouderschap eruit zou moeten zien. Daarnaast moet in het huidige wetsvoorstel voor meerouderschap de voorwaarden die aan de vorm van de relatie waarbinnen mensen voor meervoudig ouderschap kunnen kiezen losgelaten worden. Als laatste is het beter om te zeggen dat je rechten hebt of verkrijgt, dan dat deze geboden worden.