### PR TITLE
Geen koloniale energietransitie

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,11 +488,12 @@ BIJ1 heeft hiervoor de volgende plannen:
     dat we het probleem verplaatsen naar landen buiten Europa
     en klimaatracisme verder in de hand werken.
 
-1.  Er wordt fors geïnvesteerd in (nieuwe) duurzame energie-alternatieven
-    en het budget voor het warmtefonds wordt verhoogd.
-    Hierbij wordt rekening gehouden met inkomenspositie,
-    zodat mensen met lagere inkomens
-    niet de rekening gepresenteerd krijgen voor de energietransitie.
+1.  We nationaliseren energiebedrijven en investeren in (nieuwe) duurzame energie-alternatieven.
+    We passen op dat de energietransitie niet leidt tot dezelfde
+    koloniale en mens en natuur uitputtende eigenschappen heeft als de fossiele industrie.
+    Het budget voor het warmtefonds wordt verhoogd
+    en laten mensen met lagere inkomens
+    niet opdraaien voor de kosten van de energietransitie.
 
 ### Natuur en Vervoer
 


### PR DESCRIPTION
ingediend door: Myrthe

Om een energietransitie te kunnen hebben die niet doorgaat op dezelfde uitputtende en koloniale werkwijze als de fossiele industrie, moeten we energiebedrijven uit de markt halen en nationaliseren. Voor de energietransitie worden nu al zo hard grondstoffen gewonnen in het globale zuiden, met echt veel uitbuiting van mensen, dat de landen waar die grondstoffen vandaan komen, waarschijnlijk niet eens zelf gebruik kunnen maken van die grondstoffen voor hun energietransitie, omdat die grondstoffen dan al uitgeput zijn.