### PR TITLE
Hypotheekrenteaftrek afschaffen i

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,8 +583,8 @@ seksuele geaardheid, sociaaleconomische positie of verblijfsstatus.
 We zetten ons in om dak- en thuisloosheid bij de wortels aan te pakken
 en een betaalbare woning te garanderen voor iedereen.
 Het huidige woonbeleid is ondemocratisch en niet toereikend:
-daarom strijden we voor het stimuleren van andere manieren van wonen,
-zoals wooncoöperaties.
+daarom strijden we voor het stimuleren van andere manieren van wonen, zoals wooncoöperaties,
+stoppen we met het subsidiëren van koopwoningen via de hypotheekrenteaftrek en reguleren we huurprijzen.
 Daarnaast mag het opknappen van traditionele volkswijken
 niet langer leiden tot het verdringen van de bewoners.
 Gentrificatie raakt gezinnen met een kleinere portemonnee


### PR DESCRIPTION
ingediend door: Myrthe

Het afschaffen van de hypotheekrenteaftrek staat nu nog niet in het programma. We investeren als samenleving middels hypotheekrente aftrek meer in koopwoningen, dan we middels huurtoeslag in mensen met een laag inkomen investeren. Daar moeten we mee stoppen.

Daarnaast vond ik het belangrijk om in de inleiding als iets concreters op te schrijven over wat we doen om het ontoereikende en ondemocratische woonbeleid aan te pakken.