### PR TITLE
Huren betaalbaarder maken vergt systeemverandering

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,8 +641,11 @@ heeft BIJ1 de volgende plannen:
 ### Betaalbaar en Zeker Wonen
 
 1.  We maken huren betaalbaarder voor mensen,
-    door huurtoeslag onafhankelijk van woonvorm te maken
-    en door huurprijzen onmiddellijk te bevriezen.
+    door alle huurprijzen onmiddellijk te bevriezen en reguleren.
+    We verhogen de maximale inkomensgrens voor sociale huur naar 75.000 euro.
+    We stoppen met het inzetten van huurtoeslag
+    als oplossing voor het structurele probleem dat wonen onbetaalbaar is
+    en gebruiken dit geld voor de bouw van betaalbare, toegankelijke en kwalitatief goede sociale huur.
 
 1.  Huisjesmelkers maken misbruik van de wooncrisis door veel te hoge huurprijzen te vragen,
     onderhoud te verwaarlozen en soms zelfs huurders te intimideren.


### PR DESCRIPTION
ingediend door: Myrthe

Ons woonbeleid mag echt radicaler zijn. Hoewel veel mensen in het huidige systeem afhankelijk zijn van huurtoeslag om hun huren te kunnen betalen, houdt huurtoeslag het bestaan van te hoge huren in stand. In plaats van aan de achterkant voor een selecte groep mensen die in heel specifieke huizen moet wonen toeslagen in het leven te roepen, kunnen we beter aan de voorkant zorgen dat huren überhaupt goedkoper zijn. 
Door sociale huur voor een grotere groep mensen toegankelijk te maken door de maximale inkomensgrens te verhogen, erkennen we dat er veel meer mensen zijn die slecht rond kunnen komen. Dit past ook bij onze vraag om het drastisch verhogen van het percentage sociale huurwoningen.