### PR TITLE
Geen pleidooi voor Kernenergie

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,17 @@ BIJ1 heeft hiervoor de volgende plannen:
     zodat mensen met lagere inkomens
     niet de rekening gepresenteerd krijgen voor de energietransitie.
 
+1.  Kernenergie is een terraphthorane (aardvernietigende) hoax
+    in dezelfde categorie als biomassacentrales en "groene" waterstof.
+    De roof van grondstoffen uit Afrika - Niger, Namibië - het immense mijnen graven,
+    omgevingen vergiftigen gaat met uraniumwinning gewoon door.
+    Het kost decennia om centrales te bouwen met alle uitstoot van dien,
+    is onbetaalbaar en onrendabel,
+    verbruikt grote hoeveelheden broodnodig schoon water om te koelen
+    en dan is er nog de veiligheid en het 40.000 jarige afvalprobleem.
+    BIJ1 richt zich op serieuzere schone alternatieven
+    en bovenal op het verminderen van de energieverslaving van de kapitalistische industrie.
+
 ### Natuur en Vervoer
 
 1.  OV-bedrijven worden genationaliseerd.


### PR DESCRIPTION
ingediend door: Cella Grobben

De kapitalistische partijen roepen om het hardst om kernenergie om dit terraphthorane (aardvernietigende) systeem met haar energieverslaving maar overeind te houden. Kerncentrales bouwen verspilt veel bouwtechnisch vernuft dat op andere plekken in de maatschappij nodig is. En zolang er koelwaterproblemen, haarscheurtjes, veiligheidstoringen en er miljoenen liters radioactief water de pacific instromen moeten wij afzien van pleiten voor kernenergie. Wat zullen nakomelingen wel niet denken als ze over duizenden jaren die putten met radioactief materiaal open maken, goed opgelost, ik denk zomaar van niet.