### PR TITLE
Bij betalingsregelingen wordt in de eerste plaats gekeken naar draagkracht, niet naar inkomen. Het verplichte aflossen van de schuld binnen een bepaalde tijd wordt afgeschaft.

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,9 @@ Om tot deze economie te komen, heeft BIJ1 de volgende kernpunten voor ogen:
     Kwijtschelden van schulden wordt gestimuleerd,
     incassobureaus worden verboden.
 
+1.  Bij betalingsregelingen wordt in de eerste plaats gekeken naar draagkracht, niet naar inkomen.
+    Het verplichte aflossen van de schuld binnen een bepaalde tijd wordt afgeschaft.
+
 1.  Schuldhulporganisaties die geld verdienen aan andermans schulden worden verboden.
     De overheid neemt zelf de schuldhulpverlening weer in handen.
     De overheid neemt daarnaast schulden vaker over,


### PR DESCRIPTION
ingediend door: Laurens Niekel

BIJ1 is voor mensen te ontlasten van schulden en dat schulden hun leven niet gaan bepalen! Als een schuld slechts deels of niet wordt kwijt gescholden kan er een betalingsregeling worden afgesproken. Hierbij wordt gekeken naar wat iemand per periode kwijt kan gebaseerd op draagkracht/draaglast, niet op welk inkomen er per maand binnen komt of wat een instantie vindt dat een burger kan betalen gebaseerd op standaard bedragen voor vaste uitgaven (huur, g/w/l, verzekering e.d.). Burgers mogen zelf bepalen hoe lang zij over een betalingsregeling mogen doen.