### PR TITLE
Beter taalgebruik arbeidsmarkt

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Samen pakken we terug wat altijd al van ons was.
 Dit doen we op de volgende manieren:
 </mark>
 
-### Een Inclusieve en Gelijkwaardige Arbeidsmarkt
+### Inclusie en Gelijkwaardigheid in Werk en Inkomen
 
 1.  We schaffen de 40-urige werkweek af en gaan naar een 30-urige werkweek met loonbehoud.
     Partnerverlof wordt gelijkgetrokken met het kraam- en bevallingsverlof.


### PR DESCRIPTION
ingediend door: Flora en Mick namens Marxisten BIJ1

Door de term "arbeidsmarkt" te gebruiken laat je zien dat je meegaat in het kapitalistische narratief over wat arbeid is. Dat willen wij als BIJ1 absoluut niet.