### PR TITLE
Onnodig maken flexers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Dit doen we op de volgende manieren:
 1.  Krapte op de arbeidsmarkt in sectoren
     als de zorg, onderwijs en het openbaar vervoer,
     worden bestreden door flinke loonsverhogingen.
+    Zo maken we duurdere flexwerkers in deze sectoren grotendeels onnodig.
 
 1.  Werknemers die langer dan negen maanden met een tijdelijk contract werken,
     krijgen een vast contract.


### PR DESCRIPTION
ingediend door: Flora en Mick namens Marxisten BIJ1

Met name in de zorg, maar ook in het onderwijs en andere sectoren, wordt er veel winst gemaakt door uitzendbureaus die voor een hogere prijs dan reguliere lonen flexibel werknemers leveren aan instellingen met werknemerstekorten. Dit geld verdwijnt in de zakken van mensen die niets met de sector in kwestie te maken hebben. Door lonen te verhogen en arbeidsomstandigheden te verbeteren maken we het onaantrekkelijk en onnodig voor vakmensen om zulke bureau's als werkgever te kiezen.