### PR TITLE
Schrappen punt werknemersfonds aandelen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,13 +370,6 @@ Om tot deze economie te komen, heeft BIJ1 de volgende kernpunten voor ogen:
 1.  De werknemerscoöperatie wordt de standaard eigendomsstructuur
     voor nieuw opgerichte rechtspersoonlijkheden.
 
-1.  Elk bestaand beursgenoteerd bedrijf met meer dan 100 werknemers
-    wordt verplicht een werknemersfonds op te richten,
-    waaraan zij jaarlijks een aantal nieuwe aandelen,
-    proportioneel aan de jaarwinst, uitschrijven.
-    Het werknemersfonds wordt uitsluitend beheerd
-    door de werknemers van de firma die haar heeft opgericht.
-
 1.  Er wordt grootschalig onderzoek gedaan naar het duurzaam oprichten
     van publieke banken en investeringsfondsen
     die uitsluitend coöperatieven bedienen.


### PR DESCRIPTION
ingediend door: Flora en Mick namens Marxisten BIJ1

Schrap het punt over aandelenuitgifte aan medewerkers. Het is niet goed als werknemers direct afhankelijk worden van de beurswaarde van een bedrijf. Dat maakt het moeilijker voor hen om op te komen voor hun belangen. Bijvoorbeeld: het verhogen van hun lonen is slecht voor de winsten, en dus voor de aandelenuitgifte. Ook zou het in publieke handen brengen van een bedrijf de waarde van de aandelen laten instorten, waardoor werknemers dus tegen socialisatie zullen zijn, terwijl het goed is voor de samenleving, de planeet en, normaal gesproken, ook voor hen.