### PR TITLE
Verbetering formulering mensenrechten.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1907,9 +1907,10 @@ Daarvoor heeft BIJ1 de volgende kernpunten voor ogen:
 
 ### Democratie voor Iedereen
 
-1.  Alle mensenrechtenverdragen, zoals het Kinderrechtenverdrag, het Vrouwenrechtenverdrag
+1.  Internationale aanbevelingen en verdragen rond mensenrechten,
+    zoals het Kinderrechtenverdrag, het Vrouwenrechtenverdrag
     en het VN-verdrag inzake rechten van personen met een handicap,
-    krijgen rechtstreekse werking in het Nederlandse recht.
+    worden serieus genomen en, wanneer dat passend is, opgenomen in het Nederlandse recht.
     Etniciteit, afkomst, nationaliteit, genderidentiteit en genderexpressie
     worden in artikel 1 van de Grondwet opgenomen.
 


### PR DESCRIPTION
ingediend door: Flora en Mick namens Marxisten BIJ1

Het is heel gevaarlijk om alle mensenrechtenverdragen automatisch op te nemen in het nederlands recht, want wie bepaalt wat mensenrechten zijn? Er zijn ontelbare afgrijselijke misdaden gepleegd in de naam van mensenrechten, o.a. door de VS, die een zware stem hebben bij het opstellen van dit soort internationale verdragen. Bovendien wordt bezit vaak genoemd als mensenrecht, wat de democratisering van de economie dwarsboomt. Daarom moet dit punt, hoewel de intentie goed is, voorzichtiger worden geschreven.