### PR TITLE
Verbetering punt nepnieuws en racistische media.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2050,8 +2050,7 @@ Daarvoor heeft BIJ1 de volgende kernpunten voor ogen:
 
 1.  We willen een publieke omroep die onafhankelijk blijft
     en niet door de overheid of door de commercie wordt beïnvloed.
-    Omroepen die ongrondwettelijke racistische denkbeelden en nepnieuws verspreiden
-    worden verboden en krijgen geen vergunning.
+    Omroepen die racistische en discriminatoire denkbeelden verspreiden krijgen geen ruimte.
 
 ### Toegankelijkheid & Educatie
 


### PR DESCRIPTION
ingediend door: Flora en Mick namens Marxisten BIJ1

Het is onnodig om de grondwet te noemen, en dit brengt juist gevaren met zich mee voor linkse en progressieve media. In Duitsland is dit bijvoorbeeld het geval bij de repressie van de linkse krant Junge Welt door de Verfassungsschutz. Ook brengt het noemen van nepnieuws het probleem met zich mee dat er een instantie moet zijn die bepaalt wat wel en niet nepnieuws is.