### PR TITLE
De gender pay gap onder kunstenaars wordt aangepakt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2017,6 +2017,10 @@ Daarvoor heeft BIJ1 de volgende kernpunten voor ogen:
 1.  De Wet Werk & Inkomen Kunstenaars wordt weer in het leven geroepen
     en er komt structurele inzet om een einde te maken
     aan de armoede in de kunst, cultuur en mediasector.
+    Hierbij wordt extra aandacht besteed aan de gender pay gap die onder kunstenaars groter is dan in andere sectoren.
+    Er wordt een omvangrijk onderzoek ingesteld naar de oorzaken van dit grote inkomensverschil,
+    waarbij zaken als de baby-boete ('child-penalty'), de rol die kunstinstellingen, galeries,
+    verzamelaars en kunstacademies spelen in het in stand houden van deze ongelijkheid, onderzocht worden.
 
 1.  We investeren in betaalbare en toegankelijke plekken en vrijplaatsen,
     waar kunst gemaakt en getoond kan worden.


### PR DESCRIPTION
ingediend door: Emmeline de Mooij

Er is in 2022 een schokkend rapport (uitgevoerd door Women Inc. en ABN AMRO) verschenen over deze inkomensongelijkheid (https://www.womeninc.nl/actueel/man-verdient-50-procent-meer-dan-vrouw-in-kunstwereld). Omvangrijker en structureel onderzoek naar gendergelijkheid in de kunstwereld en het effect
ervan op de maatschappij is hard nodig. Hierbij is een intersectionele aanpak wenselijk en is het
relevant om ook naar kansengelijkheid rond andere diversiteitskenmerken te kijken.