### PR TITLE
Vergeet de jeugdzorgkinderen niet in de basisbeursplannen!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1731,7 +1731,7 @@ heeft BIJ1 de volgende kernpunten voor ogen:
 1.  Het collegegeld wordt afgeschaft:
     beroepsonderwijs en universiteit worden gratis.
     De basisbeurs wordt opnieuw ingevoerd en wordt inkomensafhankelijk,
-    gebaseerd op het inkomen van de ouder(s)/verzorger(s) en dat van de student zelf.
+    gebaseerd op het inkomen van de student zelf.
     Studieschulden van de 'pechgeneratie' worden kwijtgescholden.
 
 1.  Scholen moeten volledig toegankelijk worden voor leerlingen met een beperking


### PR DESCRIPTION
ingediend door: Rebekka Timmer

Het baseren van de hoogte van de basisbeurs op het inkomen van ouders dan wel verzorgers van een student, laat flink wat studenten buiten de boot vallen. Jongeren zonder contact met een ouder of verzorger - als jeugdzorgkind en vanuit eigen ervaring weet ik dat dat er veel zijn - verdienen het niet om te worden afgerekend op het salaris van die ouder.